### PR TITLE
FIX: Added throw flag to contact modal

### DIFF
--- a/app/contact/Contact.js
+++ b/app/contact/Contact.js
@@ -1,4 +1,4 @@
-import { Schema, model } from "mongoose";
+import { model, Schema } from "mongoose";
 
 export default model(
   "Contact",
@@ -26,5 +26,5 @@ export default model(
         message: (props) => `${props.value} is not a valid URL!`,
       },
     },
-  })
+  },{"strict" : "throw"})
 );


### PR DESCRIPTION
This flag will correctly throw an error when a user attempts to update a field that doesn't exist in the schema